### PR TITLE
feat: Add account deletion functionality

### DIFF
--- a/konnected_beauty/lib/core/bloc/influencer_account_deletion/influencer_account_deletion_bloc.dart
+++ b/konnected_beauty/lib/core/bloc/influencer_account_deletion/influencer_account_deletion_bloc.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'influencer_account_deletion_event.dart';
+import 'influencer_account_deletion_state.dart';
+import '../../services/api/reports_service.dart';
+
+class InfluencerAccountDeletionBloc
+    extends Bloc<InfluencerAccountDeletionEvent, InfluencerAccountDeletionState> {
+  final ReportsService reportsService;
+
+  InfluencerAccountDeletionBloc({ReportsService? service})
+      : reportsService = service ?? ReportsService(),
+        super(InfluencerAccountDeletionInitial()) {
+    on<RequestInfluencerAccountDeletion>(_onRequestAccountDeletion);
+  }
+
+  Future<void> _onRequestAccountDeletion(
+    RequestInfluencerAccountDeletion event,
+    Emitter<InfluencerAccountDeletionState> emit,
+  ) async {
+    final trimmed = event.reason.trim();
+    if (trimmed.isEmpty) {
+      emit(InfluencerAccountDeletionError(message: 'Reason is required'));
+      return;
+    }
+    
+    emit(InfluencerAccountDeletionLoading());
+    
+    final result = await reportsService.requestInfluencerAccountDeletion(
+      reason: trimmed,
+    );
+    
+    if (result['success'] == true) {
+      emit(InfluencerAccountDeletionSuccess(
+        message: result['message'] ?? 'Account deletion request submitted successfully',
+      ));
+    } else {
+      emit(InfluencerAccountDeletionError(
+        message: result['message'] ?? 'Failed to submit account deletion request',
+      ));
+    }
+  }
+}

--- a/konnected_beauty/lib/core/bloc/influencer_account_deletion/influencer_account_deletion_event.dart
+++ b/konnected_beauty/lib/core/bloc/influencer_account_deletion/influencer_account_deletion_event.dart
@@ -1,0 +1,7 @@
+abstract class InfluencerAccountDeletionEvent {}
+
+class RequestInfluencerAccountDeletion extends InfluencerAccountDeletionEvent {
+  final String reason;
+
+  RequestInfluencerAccountDeletion({required this.reason});
+}

--- a/konnected_beauty/lib/core/bloc/influencer_account_deletion/influencer_account_deletion_state.dart
+++ b/konnected_beauty/lib/core/bloc/influencer_account_deletion/influencer_account_deletion_state.dart
@@ -1,0 +1,17 @@
+abstract class InfluencerAccountDeletionState {}
+
+class InfluencerAccountDeletionInitial extends InfluencerAccountDeletionState {}
+
+class InfluencerAccountDeletionLoading extends InfluencerAccountDeletionState {}
+
+class InfluencerAccountDeletionSuccess extends InfluencerAccountDeletionState {
+  final String message;
+
+  InfluencerAccountDeletionSuccess({required this.message});
+}
+
+class InfluencerAccountDeletionError extends InfluencerAccountDeletionState {
+  final String message;
+
+  InfluencerAccountDeletionError({required this.message});
+}

--- a/konnected_beauty/lib/core/bloc/salon_account_deletion/salon_account_deletion_bloc.dart
+++ b/konnected_beauty/lib/core/bloc/salon_account_deletion/salon_account_deletion_bloc.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'salon_account_deletion_event.dart';
+import 'salon_account_deletion_state.dart';
+import '../../services/api/reports_service.dart';
+
+class SalonAccountDeletionBloc
+    extends Bloc<SalonAccountDeletionEvent, SalonAccountDeletionState> {
+  final ReportsService reportsService;
+
+  SalonAccountDeletionBloc({ReportsService? service})
+      : reportsService = service ?? ReportsService(),
+        super(SalonAccountDeletionInitial()) {
+    on<RequestSalonAccountDeletion>(_onRequestAccountDeletion);
+  }
+
+  Future<void> _onRequestAccountDeletion(
+    RequestSalonAccountDeletion event,
+    Emitter<SalonAccountDeletionState> emit,
+  ) async {
+    final trimmed = event.reason.trim();
+    if (trimmed.isEmpty) {
+      emit(SalonAccountDeletionError(message: 'Reason is required'));
+      return;
+    }
+    
+    emit(SalonAccountDeletionLoading());
+    
+    final result = await reportsService.requestSalonAccountDeletion(
+      reason: trimmed,
+    );
+    
+    if (result['success'] == true) {
+      emit(SalonAccountDeletionSuccess(
+        message: result['message'] ?? 'Account deletion request submitted successfully',
+      ));
+    } else {
+      emit(SalonAccountDeletionError(
+        message: result['message'] ?? 'Failed to submit account deletion request',
+      ));
+    }
+  }
+}

--- a/konnected_beauty/lib/core/bloc/salon_account_deletion/salon_account_deletion_event.dart
+++ b/konnected_beauty/lib/core/bloc/salon_account_deletion/salon_account_deletion_event.dart
@@ -1,0 +1,7 @@
+abstract class SalonAccountDeletionEvent {}
+
+class RequestSalonAccountDeletion extends SalonAccountDeletionEvent {
+  final String reason;
+
+  RequestSalonAccountDeletion({required this.reason});
+}

--- a/konnected_beauty/lib/core/bloc/salon_account_deletion/salon_account_deletion_state.dart
+++ b/konnected_beauty/lib/core/bloc/salon_account_deletion/salon_account_deletion_state.dart
@@ -1,0 +1,17 @@
+abstract class SalonAccountDeletionState {}
+
+class SalonAccountDeletionInitial extends SalonAccountDeletionState {}
+
+class SalonAccountDeletionLoading extends SalonAccountDeletionState {}
+
+class SalonAccountDeletionSuccess extends SalonAccountDeletionState {
+  final String message;
+
+  SalonAccountDeletionSuccess({required this.message});
+}
+
+class SalonAccountDeletionError extends SalonAccountDeletionState {
+  final String message;
+
+  SalonAccountDeletionError({required this.message});
+}

--- a/konnected_beauty/lib/core/services/api/reports_service.dart
+++ b/konnected_beauty/lib/core/services/api/reports_service.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+import 'http_interceptor.dart';
+
+class ReportsService {
+  Future<Map<String, dynamic>> sendSalonReport(
+      {required String message}) async {
+    try {
+      final trimmed = message.trim();
+      final limited =
+          trimmed.length > 255 ? trimmed.substring(0, 255) : trimmed;
+
+      final response = await HttpInterceptor.authenticatedRequest(
+        method: 'POST',
+        endpoint: '/reports/salon',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: jsonEncode({
+          'message': limited,
+        }),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        return {
+          'success': true,
+          'message': data['message'] ?? 'Report submitted successfully',
+          'data': data['data'],
+          'statusCode': response.statusCode,
+        };
+      } else {
+        final data = jsonDecode(response.body);
+        return {
+          'success': false,
+          'message': data['message'] ?? 'Failed to submit report',
+          'statusCode': response.statusCode,
+        };
+      }
+    } catch (e) {
+      return {
+        'success': false,
+        'message': 'Error submitting report: $e',
+        'statusCode': 500,
+      };
+    }
+  }
+
+  Future<Map<String, dynamic>> sendInfluencerReport(
+      {required String message}) async {
+    try {
+      final trimmed = message.trim();
+      final limited =
+          trimmed.length > 255 ? trimmed.substring(0, 255) : trimmed;
+
+      final response = await HttpInterceptor.authenticatedRequest(
+        method: 'POST',
+        endpoint: '/reports/influencer',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: jsonEncode({'message': limited}),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        return {
+          'success': true,
+          'message': data['message'] ?? 'Report submitted successfully',
+          'data': data['data'],
+          'statusCode': response.statusCode,
+        };
+      } else {
+        final data = jsonDecode(response.body);
+        return {
+          'success': false,
+          'message': data['message'] ?? 'Failed to submit report',
+          'statusCode': response.statusCode,
+        };
+      }
+    } catch (e) {
+      return {
+        'success': false,
+        'message': 'Error submitting report: $e',
+        'statusCode': 500,
+      };
+    }
+  }
+
+  /// Request account deletion for salon using existing report endpoint
+  Future<Map<String, dynamic>> requestSalonAccountDeletion({
+    required String reason,
+  }) async {
+    try {
+      print('🗑️ === REQUEST SALON ACCOUNT DELETION ===');
+      print('📝 Reason: $reason');
+
+      final response = await HttpInterceptor.authenticatedRequest(
+        method: 'POST',
+        endpoint: '/reports/salon',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: jsonEncode({
+          'message': 'ACCOUNT_DELETION_REQUEST: $reason',
+          'type': 'account_deletion_request',
+        }),
+      );
+
+      print('📡 Response Status: ${response.statusCode}');
+      print('📄 Response Body: ${response.body}');
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        return {
+          'success': true,
+          'message': data['message'] ??
+              'Account deletion request submitted successfully',
+          'data': data['data'],
+          'statusCode': response.statusCode,
+        };
+      } else {
+        final data = jsonDecode(response.body);
+        return {
+          'success': false,
+          'message':
+              data['message'] ?? 'Failed to submit account deletion request',
+          'statusCode': response.statusCode,
+        };
+      }
+    } catch (e) {
+      print('❌ Exception in requestSalonAccountDeletion: $e');
+      return {
+        'success': false,
+        'message': 'Error submitting account deletion request: $e',
+        'statusCode': 500,
+      };
+    }
+  }
+
+  /// Request account deletion for influencer using existing report endpoint
+  Future<Map<String, dynamic>> requestInfluencerAccountDeletion({
+    required String reason,
+  }) async {
+    try {
+      print('🗑️ === REQUEST INFLUENCER ACCOUNT DELETION ===');
+      print('📝 Reason: $reason');
+
+      final response = await HttpInterceptor.authenticatedRequest(
+        method: 'POST',
+        endpoint: '/reports/influencer',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: jsonEncode({
+          'message': 'ACCOUNT_DELETION_REQUEST: $reason',
+          'type': 'account_deletion_request',
+        }),
+      );
+
+      print('📡 Response Status: ${response.statusCode}');
+      print('📄 Response Body: ${response.body}');
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        return {
+          'success': true,
+          'message': data['message'] ??
+              'Account deletion request submitted successfully',
+          'data': data['data'],
+          'statusCode': response.statusCode,
+        };
+      } else {
+        final data = jsonDecode(response.body);
+        return {
+          'success': false,
+          'message':
+              data['message'] ?? 'Failed to submit account deletion request',
+          'statusCode': response.statusCode,
+        };
+      }
+    } catch (e) {
+      print('❌ Exception in requestInfluencerAccountDeletion: $e');
+      return {
+        'success': false,
+        'message': 'Error submitting account deletion request: $e',
+        'statusCode': 500,
+      };
+    }
+  }
+}

--- a/konnected_beauty/lib/core/translations/app_translations.dart
+++ b/konnected_beauty/lib/core/translations/app_translations.dart
@@ -76,7 +76,28 @@ class AppTranslations {
     'wallet': 'Portefeuille',
     'profile': 'Profil',
     'social_information': 'Informations sociales',
+    'payment_information': 'Informations de paiement',
+    'your_business_name': 'Nom de votre entreprise',
+    'business_name_placeholder': 'Ex. votre nom / nom d\'agence',
+    'registry_number_rcs': 'Numéro d\'enregistrement (RCS)',
+    'registry_number_placeholder': 'XXXX XX XXX XXX XXX',
+    'iban_number': 'Numéro IBAN',
+    'iban_number_placeholder': 'XXXX XXXX XXXX XXXX XXXX XXXX',
+    'save_informations': 'Enregistrer les informations',
+    'payment_information_updated': 'Informations de paiement mises à jour',
+    'no_changes_made': 'Aucun changement effectué',
+    'account_not_active': 'Compte non actif',
+    'account_status': 'Statut du compte',
+    'active': 'Actif',
+    'inactive': 'Inactif',
+    'salon_pictures': 'Photos du salon',
+    'upload_salon_pictures': 'Téléchargez vos photos de salon',
     'security': 'Sécurité',
+    'report': 'Signaler',
+    'report_subtitle':
+        'Envoyez vos rapports et nous vous répondrons dès que possible.',
+    'describe_your_problem': 'Décrivez votre problème',
+    'report_submitted_successfully': 'Rapport envoyé avec succès',
     'current_password': 'Mot de passe actuel',
     'new_password': 'Nouveau mot de passe',
     'confirm_new_password': 'Confirmer le nouveau mot de passe',
@@ -208,6 +229,7 @@ class AppTranslations {
     'back_to_services': 'Retour aux services',
     'service_management': 'Gestion des services',
     'no_services_found': 'Aucun service trouvé',
+    'no_services_available': 'Aucun service disponible',
     'loading_services': 'Chargement des services...',
     'refresh_services': 'Actualiser les services',
     'filter_services': 'Filtrer les services',
@@ -263,6 +285,25 @@ class AppTranslations {
     'value': 'Valeur',
     'completed_orders': 'Commandes terminées',
     'finish_campaign': 'Terminer la campagne',
+    'confirm_finish_campaign':
+        'Êtes-vous sûr de vouloir terminer cette campagne ?',
+    'congratulations_campaign_finished':
+        'Félicitations ! La campagne est terminée avec succès !',
+    'how_was_it': 'Comment c\'était ?',
+    'rate_review': 'Évaluer et commenter',
+    'rate': 'Évaluer',
+    'review': 'Commentaire',
+    'describe_your_review': 'Décrivez votre commentaire',
+    'submit': 'Soumettre',
+    'rating_submitted_successfully': 'Évaluation soumise avec succès !',
+    'thank_you_for_reviewing': 'Merci pour votre évaluation',
+    'thank_you_helping_message':
+        'Merci de nous aider à nous assurer que nous récompensons ceux qui le méritent.',
+    'filter_saloons': 'Filtrer les salons',
+    'filter_by_status': 'Filtrer par statut',
+    'verified': 'Vérifié',
+    'clear': 'Effacer',
+    'apply': 'Appliquer',
     'copy_link': 'Copier le lien',
     'delete_campaign': 'Supprimer la campagne',
     'delete_campaign_confirm':
@@ -270,6 +311,13 @@ class AppTranslations {
     'campaign_finished_success': 'Campagne terminée avec succès !',
     'campaign_link_copied': 'Lien de campagne copié dans le presse-papiers !',
     'campaign_deleted_success': 'Campagne supprimée avec succès !',
+    'delete_campaign_request': 'Supprimer la demande de campagne',
+    'campaign_request_deleted': 'Demande de campagne supprimée avec succès',
+    'delete_campaign_confirmation_title': 'Confirmer la suppression',
+    'delete_campaign_confirmation_message':
+        'Êtes-vous sûr de vouloir supprimer cette demande de campagne ? Cette action ne peut pas être annulée.',
+    'delete_campaign_confirm_button': 'Supprimer',
+    'delete_campaign_cancel_button': 'Annuler',
     'influencers': 'Influenceurs',
     'settings': 'Paramètres',
 
@@ -364,6 +412,7 @@ class AppTranslations {
     'no_social_media_available': 'Aucun lien de réseau social disponible',
     'reviews': 'Avis',
     'no_reviews_available': 'Aucun avis disponible pour le moment',
+    'no_comment': 'Aucun commentaire',
     'unknown_salon': 'Salon inconnu',
 
     // Saloons Screen
@@ -445,14 +494,68 @@ class AppTranslations {
     'refuse': 'Refuser',
     'waiting_for_you': 'En attente de vous',
     'on_going': 'En cours',
+    'on_going_status': 'En cours',
+    'confirm_accept_campaign':
+        'Êtes-vous sûr de vouloir accepter cette campagne ?',
+    'confirm_refuse_campaign':
+        'Êtes-vous sûr de vouloir refuser cette campagne ?',
+    'confirm': 'Confirmer',
+    'wait': 'Attendre',
+    'Waiting_for_Saloon': 'En attente du salon',
+    'waiting_for_salon': 'En attente du salon',
+    'waiting_for_influencer': 'En attente de l\'influenceur',
+    'refused': 'Refusé',
     'finished': 'Terminé',
     'orders': 'Commandes',
     'campaigns_will_appear_here':
         'Les invitations de campagne et les collaborations apparaîtront ici',
     'refresh': 'Actualiser',
+
+    // Campaigns Screen Additional
+    'no_message': 'Aucun message',
+    'today': 'Aujourd\'hui',
+    'yesterday': 'Hier',
+    'no_more_campaigns': 'Plus de campagnes à charger',
+    'error_loading_campaigns': 'Erreur lors du chargement des campagnes',
+    'no_campaigns_found': 'Aucune campagne trouvée',
     'try_again': 'Réessayer',
     'total': 'Total',
     'message': 'Message',
+
+    // Campaign Details Screen
+
+    'percentage': 'Pourcentage',
+    'fixed': 'Fixe',
+    'fixed_amount': 'Montant fixe',
+
+    // Account Deletion
+    'delete_account': 'Supprimer le compte',
+    'account_deletion': 'Suppression du compte',
+    'account_deletion_request': 'Demande de suppression de compte',
+    'account_deletion_reason': 'Raison de la suppression',
+    'account_deletion_warning':
+        'Cette action est irréversible. Toutes vos données seront supprimées définitivement.',
+    'account_deletion_confirm': 'Confirmer',
+    'account_deletion_success': 'Demande de suppression soumise avec succès',
+    'account_deletion_error': 'Erreur lors de la soumission de la demande',
+    'account_deletion_placeholder':
+        'Veuillez expliquer pourquoi vous souhaitez supprimer votre compte...',
+    'account_deletion_required': 'La raison est requise',
+    'account_deletion_cancel': 'Annuler',
+
+    // Invite Salon
+    'invitation_sent_successfully': 'Invitation envoyée avec succès',
+    'invitation_failed': 'Échec de l\'invitation',
+    'invitation_message_default': 'Voulez-vous collaborer ?',
+    'promotion': 'Promotion',
+
+    'sending_invitation': 'Envoi de l\'invitation...',
+    'invitation_link': 'Lien d\'invitation',
+    'invitation_status': 'Statut de l\'invitation',
+    'pending': 'En attente',
+    'accepted': 'Accepté',
+    'rejected': 'Rejeté',
+    'all': 'Tous',
   };
 
   // English translations
@@ -510,7 +613,28 @@ class AppTranslations {
     'wallet': 'Wallet',
     'profile': 'Profile',
     'social_information': 'Social Information',
+    'payment_information': 'Payment Information',
+    'your_business_name': 'Your business name',
+    'business_name_placeholder': 'E.g your name / agency name',
+    'registry_number_rcs': 'Registry number (RCS)',
+    'registry_number_placeholder': 'XXXX XX XXX XXX XXX',
+    'iban_number': 'IBAN number',
+    'iban_number_placeholder': 'XXXX XXXX XXXX XXXX XXXX XXXX',
+    'save_informations': 'Save informations',
+    'payment_information_updated': 'Payment information updated',
+    'no_changes_made': 'No changes made',
+    'account_not_active': 'Account not active',
+    'account_status': 'Account Status',
+    'active': 'Active',
+    'inactive': 'Inactive',
+    'salon_pictures': 'Salon Pictures',
+    'upload_salon_pictures': 'Upload your salon pictures',
     'security': 'Security',
+    'report': 'Report',
+    'report_subtitle':
+        'Send your reports and we will reply as soon as possible.',
+    'describe_your_problem': 'Describe your problem',
+    'report_submitted_successfully': 'Report submitted successfully',
     'current_password': 'Current password',
     'new_password': 'New password',
     'confirm_new_password': 'Confirm new password',
@@ -619,6 +743,7 @@ class AppTranslations {
     'back_to_services': 'Back to Services',
     'service_management': 'Service Management',
     'no_services_found': 'No services found',
+    'no_services_available': 'No services available',
     'loading_services': 'Loading services...',
     'refresh_services': 'Refresh Services',
     'filter_services': 'Filter Services',
@@ -671,12 +796,37 @@ class AppTranslations {
     'value': 'Value',
     'completed_orders': 'Completed orders',
     'finish_campaign': 'Finish campaign',
+    'confirm_finish_campaign': 'Are you sure you want to finish this campaign?',
+    'congratulations_campaign_finished':
+        'Congratulations! The campaign has been finished successfully!',
+    'how_was_it': 'How was it ?',
+    'rate_review': 'Rate & review',
+    'rate': 'Rate',
+    'review': 'Review',
+    'describe_your_review': 'Describe your review',
+    'submit': 'Submit',
+    'rating_submitted_successfully': 'Rating submitted successfully!',
+    'thank_you_for_reviewing': 'Thank you for reviewing',
+    'thank_you_helping_message':
+        'Thank you for helping us, to make sure we rewards those who deserve it.',
+    'filter_saloons': 'Filter Salons',
+    'filter_by_status': 'Filter by Status',
+    'verified': 'Verified',
+    'clear': 'Clear',
+    'apply': 'Apply',
     'copy_link': 'Copy link',
     'delete_campaign': 'Delete campaign',
     'delete_campaign_confirm': 'Are you sure you want to delete this campaign?',
     'campaign_finished_success': 'Campaign finished successfully!',
     'campaign_link_copied': 'Campaign link copied to clipboard!',
     'campaign_deleted_success': 'Campaign deleted successfully!',
+    'delete_campaign_request': 'Delete campaign request',
+    'campaign_request_deleted': 'Campaign request deleted successfully',
+    'delete_campaign_confirmation_title': 'Confirm Deletion',
+    'delete_campaign_confirmation_message':
+        'Are you sure you want to delete this campaign request? This action cannot be undone.',
+    'delete_campaign_confirm_button': 'Delete',
+    'delete_campaign_cancel_button': 'Cancel',
     'influencers': 'Influencers',
     'settings': 'Settings',
 
@@ -783,6 +933,7 @@ class AppTranslations {
     'no_social_media_available': 'No social media links available',
     'reviews': 'Reviews',
     'no_reviews_available': 'No reviews available yet',
+    'no_comment': 'No comment',
     'unknown_salon': 'Unknown Salon',
 
     // Saloons Screen
@@ -862,13 +1013,66 @@ class AppTranslations {
     'refuse': 'Refuse',
     'waiting_for_you': 'Waiting for you',
     'on_going': 'On going',
+    'on_going_status': 'On going',
+    'confirm_accept_campaign': 'Are you sure you want to accept this campaign?',
+    'confirm_refuse_campaign': 'Are you sure you want to refuse this campaign?',
+    'confirm': 'Confirm',
+    'wait': 'Wait',
+    'Waiting_for_Saloon': 'Waiting for Salon',
+    'waiting_for_salon': 'Waiting for Salon',
+    'waiting_for_influencer': 'Waiting for Influencer',
+    'refused': 'Refused',
     'finished': 'Finished',
     'orders': 'Orders',
     'campaigns_will_appear_here':
         'Campaign invitations and collaborations will appear here',
+
+    // Campaigns Screen Additional
+    'no_message': 'No message',
+    'today': 'Today',
+    'yesterday': 'Yesterday',
+    'no_more_campaigns': 'No more campaigns to load',
+    'error_loading_campaigns': 'Error loading campaigns',
+    'no_campaigns_found': 'No campaigns found',
     'refresh': 'Refresh',
     'try_again': 'Try again',
     'total': 'Total',
     'message': 'Message',
+
+    // Campaign Details Screen
+
+    'percentage': 'Percentage',
+    'fixed': 'Fixed',
+    'fixed_amount': 'Fixed Amount',
+
+    // Account Deletion
+    'delete_account': 'Delete Account',
+    'account_deletion': 'Account Deletion',
+    'account_deletion_request': 'Account Deletion Request',
+    'account_deletion_reason': 'Reason for Deletion',
+    'account_deletion_warning':
+        'This action is irreversible. All your data will be permanently deleted.',
+    'account_deletion_confirm': 'Confirm',
+    'account_deletion_success':
+        'Account deletion request submitted successfully',
+    'account_deletion_error': 'Error submitting deletion request',
+    'account_deletion_placeholder':
+        'Please explain why you want to delete your account...',
+    'account_deletion_required': 'Reason is required',
+    'account_deletion_cancel': 'Cancel',
+
+    // Invite Salon
+    'invitation_sent_successfully': 'Invitation sent successfully',
+    'invitation_failed': 'Invitation failed',
+    'invitation_message_default': 'Want to collaborate?',
+    'promotion': 'Promotion',
+
+    'sending_invitation': 'Sending invitation...',
+    'invitation_link': 'Invitation Link',
+    'invitation_status': 'Invitation Status',
+    'pending': 'Pending',
+    'accepted': 'Accepted',
+    'rejected': 'Rejected',
+    'all': 'All',
   };
 }

--- a/konnected_beauty/lib/widgets/common/account_deletion_dialog.dart
+++ b/konnected_beauty/lib/widgets/common/account_deletion_dialog.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../core/translations/app_translations.dart';
+import '../../core/bloc/salon_account_deletion/salon_account_deletion_bloc.dart';
+import '../../core/bloc/salon_account_deletion/salon_account_deletion_event.dart';
+import '../../core/bloc/salon_account_deletion/salon_account_deletion_state.dart';
+import '../../core/bloc/influencer_account_deletion/influencer_account_deletion_bloc.dart';
+import '../../core/bloc/influencer_account_deletion/influencer_account_deletion_event.dart';
+import '../../core/bloc/influencer_account_deletion/influencer_account_deletion_state.dart';
+import '../../core/theme/app_theme.dart';
+import 'top_notification_banner.dart';
+
+class AccountDeletionDialog extends StatefulWidget {
+  final String userType; // 'salon' or 'influencer'
+
+  const AccountDeletionDialog({
+    super.key,
+    required this.userType,
+  });
+
+  @override
+  State<AccountDeletionDialog> createState() => _AccountDeletionDialogState();
+}
+
+class _AccountDeletionDialogState extends State<AccountDeletionDialog> {
+  final TextEditingController _reasonController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
+  }
+
+  void _submitDeletionRequest() {
+    final reason = _reasonController.text.trim();
+    if (reason.isEmpty) {
+      TopNotificationService.showError(
+        context: context,
+        message:
+            AppTranslations.getString(context, 'account_deletion_required'),
+      );
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+    });
+
+    if (widget.userType == 'salon') {
+      context.read<SalonAccountDeletionBloc>().add(
+            RequestSalonAccountDeletion(reason: reason),
+          );
+    } else {
+      context.read<InfluencerAccountDeletionBloc>().add(
+            RequestInfluencerAccountDeletion(reason: reason),
+          );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppTheme.primaryColor,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
+            Row(
+              children: [
+                Icon(
+                  Icons.warning_amber_rounded,
+                  color: Colors.red,
+                  size: 28,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    AppTranslations.getString(context, 'account_deletion'),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(
+                    Icons.close,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // Warning message
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.red.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.red.withOpacity(0.3)),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    color: Colors.red,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      AppTranslations.getString(
+                          context, 'account_deletion_warning'),
+                      style: TextStyle(
+                        color: Colors.red[300],
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // Reason input
+            Text(
+              AppTranslations.getString(context, 'account_deletion_reason'),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _reasonController,
+              maxLines: 4,
+              maxLength: 500,
+              style: const TextStyle(color: Colors.white),
+              decoration: InputDecoration(
+                hintText: AppTranslations.getString(
+                    context, 'account_deletion_placeholder'),
+                hintStyle: TextStyle(color: Colors.grey[400]),
+                filled: true,
+                fillColor: Colors.grey[800],
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.all(12),
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Action buttons
+            Row(
+              children: [
+                Expanded(
+                  child: TextButton(
+                    onPressed: _isSubmitting
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                    style: TextButton.styleFrom(
+                      backgroundColor: Colors.grey[700],
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: Text(
+                      AppTranslations.getString(
+                          context, 'account_deletion_cancel'),
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _buildSubmitButton(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSubmitButton() {
+    if (widget.userType == 'salon') {
+      return BlocListener<SalonAccountDeletionBloc, SalonAccountDeletionState>(
+        listener: (context, state) {
+          if (state is SalonAccountDeletionSuccess) {
+            setState(() {
+              _isSubmitting = false;
+            });
+            Navigator.of(context).pop();
+            TopNotificationService.showSuccess(
+              context: context,
+              message: state.message,
+            );
+          } else if (state is SalonAccountDeletionError) {
+            setState(() {
+              _isSubmitting = false;
+            });
+            TopNotificationService.showError(
+              context: context,
+              message: state.message,
+            );
+          }
+        },
+        child: ElevatedButton(
+          onPressed: _isSubmitting ? null : _submitDeletionRequest,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.red,
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+          child: _isSubmitting
+              ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : Text(
+                  AppTranslations.getString(
+                      context, 'account_deletion_confirm'),
+                  style: const TextStyle(color: Colors.white),
+                ),
+        ),
+      );
+    } else {
+      return BlocListener<InfluencerAccountDeletionBloc,
+          InfluencerAccountDeletionState>(
+        listener: (context, state) {
+          if (state is InfluencerAccountDeletionSuccess) {
+            setState(() {
+              _isSubmitting = false;
+            });
+            Navigator.of(context).pop();
+            TopNotificationService.showSuccess(
+              context: context,
+              message: state.message,
+            );
+          } else if (state is InfluencerAccountDeletionError) {
+            setState(() {
+              _isSubmitting = false;
+            });
+            TopNotificationService.showError(
+              context: context,
+              message: state.message,
+            );
+          }
+        },
+        child: ElevatedButton(
+          onPressed: _isSubmitting ? null : _submitDeletionRequest,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.red,
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+          child: _isSubmitting
+              ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : Text(
+                  AppTranslations.getString(
+                      context, 'account_deletion_confirm'),
+                  style: const TextStyle(color: Colors.white),
+                ),
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
- Add account deletion API using existing reports endpoints
- Create BLoCs for salon and influencer account deletion
- Add account deletion UI to salon settings and influencer home screens
- Add translations for account deletion feature
- Use TopNotificationBanner for user feedback
- Implement Apple compliance for account deletion (Guideline 5.1.1(v))